### PR TITLE
updates and fixes to various templates

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -53,7 +53,10 @@ spec:
         {{- range .Values.secrets.volumes }}
         - name: {{ .name }}
           secret:
-            - secretName: {{ .name | replace "_" "-" }}
+            secretName: {{ .name | replace "_" "-" }}
+            items:
+            - key: secret
+              path: {{ .path | default .name }}
         {{- end }}
         {{- end }}
       {{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -17,7 +17,10 @@ metadata:
     {{- end }}
 type: {{ $secret.type | default "Opaque" }}
 data:
+  {{- if eq ($secret.type | default "Opaque") "Opaque" }}
   secret: {{ $secret.value | b64enc }}
-
+  {{- else }}
+  secret: {{ $secret.value }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -17,10 +17,6 @@ metadata:
     {{- end }}
 type: {{ $secret.type | default "Opaque" }}
 data:
-  {{- if eq ($secret.type | default "Opaque") "Opaque" }}
   secret: {{ $secret.value | b64enc }}
-  {{- else }}
-  secret: {{ $secret.value }}
-  {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,6 +21,7 @@ image:
 
 ## Pull secrets for pulling private images.
 imagePullSecrets: []
+#  - name: my-pull-secret
 
 ## Values to encapsulate as Secrets.
 ## Note that Secret names must be a valid DNS subdomain name.


### PR DESCRIPTION
This PR:
- adds an example for what the image pull secrets should look like
- fixes a error in the template for how volume mounted secrets are defined
- use the path of the volume mounted secret as the mount destination in the container

This also attempted to do some fancy gating around when to b64 encode a secret or not, but I think it was a bad decision, so I reverted it. I believe I mis-read the docs initially saying that only Opaque secrets should be b64 encoded, but after looking again, I believe all values should be b64 encoded.