### PR TITLE
Lowercase secret names

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         {{- range .Values.secrets.volumes }}
         - name: {{ .name }}
           secret:
-            secretName: {{ .name | replace "_" "-" }}
+            secretName: {{ .name | replace "_" "-" | lower }}
             items:
             - key: secret
               path: {{ .path | default .name }}
@@ -84,7 +84,7 @@ spec:
             - name: {{ .name | replace "-" "_" | upper }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .name | replace "_" "-" }}
+                  name: {{ .name | replace "_" "-" | lower }}
                   key: secret
             {{- end }}
             {{- end }}
@@ -96,7 +96,7 @@ spec:
             {{- end }}
             {{- if .Values.secrets.volumes }}
             {{- range .Values.secrets.volumes }}
-            - name: {{ .name }}
+            - name: {{ .name  | replace "-" "_" | lower }}
               mountPath: /secrets
             {{- end }}
             {{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secret.name | replace "_" "-" }}
+  name: {{ $secret.name | replace "_" "-" | lower }}
   {{- with $secret.annotations }}
   annotations:
     {{- toYaml . | trim | nindent 4 }}
@@ -20,3 +20,4 @@ data:
   secret: {{ $secret.value | b64enc }}
 {{- end }}
 {{- end }}
+


### PR DESCRIPTION
- Conform to the DNS spec, Most resource types require a name that can
  be used as a DNS subdomain name as defined in RFC 1123. This means the
  name must:

- contain no more than 253 characters
- contain only lowercase alphanumeric characters, '-' or '.'
- start with an alphanumeric character
- end with an alphanumeric character

Do we need to trunc and rtrim '-' as well?