### PR TITLE
Bump ingress value comments with current "defaults"

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -92,8 +92,8 @@ service:
 ingress:
   enabled: false
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.class: internal
+    # cert-manager.io/cluster-issuer: le-gdns
   labels: {}
   hosts: []
   #  - host: chart-example.local


### PR DESCRIPTION
- use cert-manager.io vs acme
- specify internal ingress, a sensible default