### PR TITLE
Update ingress template to target 1.18+ since our domain is from 1.17+

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare ">=1.19.0-0" $kubeTargetVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else  -}}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -37,6 +38,12 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             backend:
+          {{- if semverCompare ">=1.19.0-0" $kubeTargetVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- else  }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
           {{- end }}


### PR DESCRIPTION
- Ingress updated to v1 in 2020. This bumps our templates up from a 3
  year old pattern to determine version skew for api objects. I didnt
  check to see if this fails any lints :crossed_fingers: