### PR TITLE
Append missing pathType

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -37,6 +37,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
           {{- if semverCompare ">=1.19.0-0" $kubeTargetVersion }}
               service:


### PR DESCRIPTION
V1 ingress now requries a pathType https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types and I missed this on the first pass.