### PR TITLE
add default gate around env block rendering

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -79,6 +79,7 @@ spec:
           {{- with .Values.args }}
           args: {{ . }}
           {{- end }}
+          {{- if (or .Values.env .Values.secrets.env) }}
           env:
             {{- with .Values.env }}
             {{- toYaml . | trim | nindent 12 }}
@@ -92,6 +93,7 @@ spec:
                   key: secret
             {{- end }}
             {{- end }}
+          {{- end }}
           {{- if (or .Values.config .Values.secrets.volumes) }}
           volumeMounts:
             {{- if .Values.config }}


### PR DESCRIPTION
This PR:
- adds a default gate around env block rendering
  - this was initially omitted at first because a bunch of applications declare configuration via env, so the thought was they would add that in and we'd no longer need the gate, but that assumption did not hold for 2 apps now, so this feels worthwhile to put in.